### PR TITLE
Lock lottie-ios on version 2.5.0

### DIFF
--- a/lottie-react-native.podspec
+++ b/lottie-react-native.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files  = "src/ios/**/*.{h,m}"
 
   s.dependency 'React'
-  s.dependency 'lottie-ios'
+  s.dependency 'lottie-ios', '~> 2.5.0'
 end

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "invariant": "^2.2.2",
-    "lottie-ios": "^2.5.0",
+    "lottie-ios": "2.5.0",
     "prop-types": "^15.5.10",
     "react-native-safe-module": "^1.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3327,7 +3327,7 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   dependencies:
     js-tokens "^3.0.0"
 
-lottie-ios@^2.5.0:
+lottie-ios@2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/lottie-ios/-/lottie-ios-2.5.0.tgz#55c808e785d4a6933b0c10b395530b17098b05de"
 


### PR DESCRIPTION
There are compilation errors with 2.5.3 from npmjs repository so we should lock lottie-ios on 2.5.0 until we will migrate to 3.x.x