### PR TITLE
Resolve missing prop mock warning

### DIFF
--- a/src/js/LottieView.js
+++ b/src/js/LottieView.js
@@ -22,6 +22,7 @@ const LottieViewManager = SafeModule.module({
   mock: {
     play: () => {},
     reset: () => {},
+    getConstants: () => {},
   },
 });
 


### PR DESCRIPTION
# Issue

Since react-native 0.58.0-rc.0 `react-native-safe-module` is throwing a `missing prop mock` warning defined [here](https://github.com/lelandrichardson/react-native-safe-module/blob/master/src/NativeSafeModule.js#L114) since `getConstants` mock is missing (`getConstants` become a part of native modules API in [this](https://github.com/facebook/react-native/commit/db43aa8fc3dd9ca87d227df0c109a6f5c213f90b) commit).

# Steps to reproduce

Require `lottie-react-native` in any project with react-native >= 0.58.0-rc.0