### PR TITLE
Update lottie-android to 2.6.1 to work with cacheStrategy

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -32,5 +32,5 @@ dependencies {
 
   compileOnly "com.facebook.react:react-native:+"
   implementation "com.android.support:appcompat-v7:$supportLibVersion"
-  implementation 'com.airbnb.android:lottie:2.5.6'
+  implementation 'com.airbnb.android:lottie:2.6.1'
 }


### PR DESCRIPTION
Android 28 and React native 0.59 works great with lottie 2.6.1, but 2.6 seems to break with cache strategy, even though its been deprecated.. This bumps the version to work with cache strategy