### PR TITLE
Remove sub dependency

### DIFF
--- a/lottie-react-native.podspec
+++ b/lottie-react-native.podspec
@@ -15,6 +15,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/react-community/lottie-react-native.git", :tag => "v#{s.version}" }
   s.source_files  = "src/ios/**/*.{h,m}"
 
-  s.dependency 'React'
   s.dependency 'lottie-ios', '~> 2.5.0'
 end


### PR DESCRIPTION
# Summary
Currently, React Pod has been deprecated, and it also leads to conflict between `package.json` of Pod's React project and React project. 

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged

* What is the feature? (if applicable)
Remove sub dependency
* How did you implement the solution?
Just remove sub dependency from podspec.

* What areas of the library does it impact?
It affects iOS.

## Test Plan
There is not React dependency
![image](https://user-images.githubusercontent.com/40555128/58314934-bc11d900-7e3a-11e9-9514-49552a945a5f.png)

### What's required for testing (prerequisites)?
NO

### What are the steps to reproduce (after prerequisites)?
1. Install lottie-react-native lib
2. `cd ios/ && pod install`
3. Run react native after all
## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
