### PR TITLE
Add doc for hardwareAccelerationAndroid

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -12,6 +12,7 @@
 |**`style`**|Style attributes for the view, as expected in a standard [`View`](http://facebook.github.io/react-native/releases/0.46/docs/layout-props.html), aside from border styling |*None*|
 |**`imageAssetsFolder`**| Needed for **Android** to work properly with assets, iOS will ignore it. |*None*|
 |**`cacheStrategy`**| Needed for **Android** for performance tuning reasons. Possible values are: 'strong' - kept in memory forever, 'weak' - cache while in active use, 'none' - not cache, iOS will ignore it. |*weak*|
+|**`hardwareAccelerationAndroid`**| Only for **Android**. Uses hardware acceleration to perform the animation. This should only be used for animations where your width and height are equal to the composition width and height, e.g. you are not scaling the animation. |`false`|
 |**`onAnimationFinish`**| A callback function which will be called when animation is finished. Note that this callback will be called only when `loop` is set to false. |*None*|
 
 ## Methods (Imperative API):


### PR DESCRIPTION
# Summary

I found on the file `src/js/index.d.ts` the `hardwareAccelerationAndroid` prop. It wasn't described on the API documentation.

## Checklist

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)
