### PR TITLE
Remove deprecated `rnpm` configuration.

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,10 +71,5 @@
     "eslint-plugin-prettier": "^2.3.1",
     "prettier": "^1.8.2",
     "prettier-eslint": "^8.2.2"
-  },
-  "rnpm": {
-    "android": {
-      "sourceDir": "./src/android"
-    }
   }
 }


### PR DESCRIPTION
It could have impact on android build but as we package supports RN 60 it should not make any difference.

## Test Plan

### What's required for testing (prerequisites):
- Build android project.

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I added the documentation in `README.md`
