### PR TITLE
Fix crash on Android and RN 0.60

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,8 +1,9 @@
 module.exports = {
-  project: {
-    ios: {},
-    android: {
-      sourceDir: './src/android',
-    }, // grouped into "project"
+  dependency: {
+    platforms: {
+      android: {
+        sourceDir: './src/android',
+      },
+    },
   },
 };


### PR DESCRIPTION
Related to : #521 

This config makes `autolink` work properly.

I hope this helps.