### PR TITLE
support for lottie android 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,117 +1,131 @@
+## 3.1.0 (Jul 25, 2019)
+
+* Support for `lottie-android` 3.0.0
+
+## 3.0.4 (Jul 23, 2019)
+
+* Fix for auto linking on Android
+
+## 3.0.3 (Jul 22, 2019)
+
+* Support for AndroidX
+* Removed deprecated rnpm support
+* Updated dependency for react-native-safe-module
+
 ## 3.0.2 (Jul 13, 2019)
 
-- Lock lottie-ios on version 3.3.0
+* Lock lottie-ios on version 3.3.0
 
 ## 3.0.1 (Jun 28, 2019)
 
-- Resolving UIViewManager deprecation warning
+* Resolving UIViewManager deprecation warning
 
 ## 3.0.0 (Jun 1, 2019)
 
-- React Native lottie upgrade (iOS)
+* React Native lottie upgrade (iOS)
 
 ## 2.6.1 (March 29, 2019)
 
-- Lock lottie-ios on version 2.5.0
-- Enable RN projects to define the Android AppCompat Library version
+* Lock lottie-ios on version 2.5.0
+* Enable RN projects to define the Android AppCompat Library version
 
 ## 2.6.0 (March 18, 2019)
 
-- Add Android app compatability support for RN 0.59 on Android (#455)
+* Add Android app compatability support for RN 0.59 on Android (#455)
 
 ## 2.5.11 (December 20, 2018)
 
-- Improved documentation
-- Added `onAnimationFinish` callback
-- Fixed compilation errors
+* Improved documentation
+* Added `onAnimationFinish` callback
+* Fixed compilation errors
 
 ## 2.5.10 (November 6, 2018)
 
-- Fixed proptype checking on LottieView
-- Added missing typings
-- Use commonjs object export compatible syntax
+* Fixed proptype checking on LottieView
+* Added missing typings
+* Use commonjs object export compatible syntax
 
 ## 2.5.9 (October 10, 2018)
 
-- Fixed Android build - deprecated build script directives
-- Fixed iOS build - header search paths
-- Added missing typings
+* Fixed Android build - deprecated build script directives
+* Fixed iOS build - header search paths
+* Added missing typings
 
 ## 2.5.8 (August 27, 2018)
 
-- Fixed Android flickering
-- Added missing duration prop
+* Fixed Android flickering
+* Added missing duration prop
 
 ## 2.5.7 (August 27, 2018)
 
-- Fixed Android play method to be run only when the view is attached
+* Fixed Android play method to be run only when the view is attached
 
 ## 2.5.6 (August 1, 2018)
 
-- Reverted dependencies to ensure compatibility with RN
+* Reverted dependencies to ensure compatibility with RN
 
 ## 2.5.5 (August 1, 2018)
 
-- Fixed Android builds
+* Fixed Android builds
 
 ## 2.5.1 (July 30, 2018)
 
-- Fixed built library
-- Refactor + RN 0.56
-- Autoplay animations when animation's source has changed
-- Use project-wide properties and new dependency
+* Fixed built library
+* Refactor + RN 0.56
+* Autoplay animations when animation's source has changed
+* Use project-wide properties and new dependency
 
 ## 2.5.0 (April 3, 2018)
 
-- Fixed typescript support
-- Bump Lottie to 2.5
-- Support Carthage projects
-- Fix resizeMode for iOS and TypeScript
+* Fixed typescript support
+* Bump Lottie to 2.5
+* Support Carthage projects
+* Fix resizeMode for iOS and TypeScript
 
 ## 2.3.2 (January 5, 2018)
 
-- Moved eslint deps to devDeps
-- Expose hardwareAccelerationAndroid (#254)
+* Moved eslint deps to devDeps
+* Expose hardwareAccelerationAndroid (#254)
 
 ## 2.3.1 (December 5, 2017)
 
-- Bumped lottie-ios and lottie-android
+* Bumped lottie-ios and lottie-android
 
 ## 2.3.0 (November 24, 2017)
 
 ### Features and Improvements
 
-- speed prop
-- enableMergePathsAndroidForKitKatAndAbove prop for Android KitKat and above
-- Bump Lottie-Android to 2.3.0
-- Bump Lottie-iOS to 2.1.4
-- Added resizeMode prop similar to <Image>
-- Added play(fromFrame, toFrame)
-- Removed the need for a style prop
+* speed prop
+* enableMergePathsAndroidForKitKatAndAbove prop for Android KitKat and above
+* Bump Lottie-Android to 2.3.0
+* Bump Lottie-iOS to 2.1.4
+* Added resizeMode prop similar to <Image>
+* Added play(fromFrame, toFrame)
+* Removed the need for a style prop
   ### Bugs Fixed
-- Improved the json serialization perf ~10x
-- Fixed some build related issues on iOS and for newer versions of RN
-- Enabled dev menu and reload for Android and iOS sample apps
+* Improved the json serialization perf ~10x
+* Fixed some build related issues on iOS and for newer versions of RN
+* Enabled dev menu and reload for Android and iOS sample apps
 
 ## 1.0.6 (Feb 13, 2017)
 
-- Fix name conflict with new release of ios cocoapod
+* Fix name conflict with new release of ios cocoapod
 
 ## 1.0.5 (Feb 10, 2017)
 
-- Allow iOS to be statically linked properly with react-native link
+* Allow iOS to be statically linked properly with react-native link
 
 ## 1.0.2 - 1.0.4 (Feb 8, 2017)
 
-- Fix Android NativeModule name
-- Depend on lottie-ios through NPM in order to make static linking easier
-- Fix bad Lottie.xcodeproj reference for static linking
-- Fix iOS header import order for static linking
+* Fix Android NativeModule name
+* Depend on lottie-ios through NPM in order to make static linking easier
+* Fix bad Lottie.xcodeproj reference for static linking
+* Fix iOS header import order for static linking
 
 ## 1.0.1 (Feb 2, 2017)
 
-- Fix Header / Build issues with iOS on RN 0.40+
+* Fix Header / Build issues with iOS on RN 0.40+
 
 ## 1.0.0 (Feb 1, 2017)
 
-- Official Release!
+* Official Release!

--- a/build.gradle
+++ b/build.gradle
@@ -2,15 +2,17 @@
 
 buildscript {
   repositories {
+    google()
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.3'
+    classpath 'com.android.tools.build:gradle:3.3.0'
   }
 }
 
 allprojects {
   repositories {
+    google()
     mavenLocal()
     jcenter()
     maven {

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,8 +11,6 @@
 |**`autoSize`**|A boolean flag indicating whether or not the animation should size itself automatically according to the width in the animation's JSON. This only works when `source` is an actual JS object of an animation.  |`false`|
 |**`style`**|Style attributes for the view, as expected in a standard [`View`](http://facebook.github.io/react-native/releases/0.46/docs/layout-props.html), aside from border styling |*None*|
 |**`imageAssetsFolder`**| Needed for **Android** to work properly with assets, iOS will ignore it. |*None*|
-|**`cacheStrategy`**| Needed for **Android** for performance tuning reasons. Possible values are: 'strong' - kept in memory forever, 'weak' - cache while in active use, 'none' - not cache, iOS will ignore it. |*weak*|
-|**`hardwareAccelerationAndroid`**| Only for **Android**. Uses hardware acceleration to perform the animation. This should only be used for animations where your width and height are equal to the composition width and height, e.g. you are not scaling the animation. |`false`|
 |**`onAnimationFinish`**| A callback function which will be called when animation is finished. Note that this callback will be called only when `loop` is set to false. |*None*|
 
 ## Methods (Imperative API):

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -97,8 +97,7 @@ def enableSeparateBuildPerCPUArchitecture = false
 def enableProguardInReleaseBuilds = false
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.1"
+    compileSdkVersion 28
 
     defaultConfig {
         applicationId "com.airbnb.android"
@@ -137,14 +136,17 @@ android {
             }
         }
     }
+
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
 }
 
 dependencies {
-    compile project(':lottie-react-native')
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile 'com.android.support:support-annotations:26.1.0'
-    compile "com.facebook.react:react-native:+"  // From node_modules
-
+    implementation project(':lottie-react-native')
+    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation "com.facebook.react:react-native:+"
 }
 
 // Run this once to be able to run the application with BUCK

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.example"
     android:versionCode="1"
     android:versionName="1.0">
@@ -6,16 +7,13 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
-    <uses-sdk
-        android:minSdkVersion="16"
-        android:targetSdkVersion="22" />
-
     <application
       android:name=".MainApplication"
       android:allowBackup="true"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
-      android:theme="@style/AppTheme">
+      android:theme="@style/AppTheme"
+      tools:ignore="AllowBackup,GoogleAppIndexingWarning">
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lottie-react-native",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "React Native bindings for Lottie",
   "main": "lib/index.js",
   "types": "src/js/index.d.ts",
@@ -21,24 +21,19 @@
     "docs:prepare": "gitbook install",
     "docs:build": "npm run docs:prepare && gitbook build",
     "docs:watch": "npm run docs:prepare && gitbook serve",
-    "docs:publish": "npm run docs:clean && npm run docs:build && cd _book && git init && git commit --allow-empty -m 'update book' && git fetch git@github.com:airbnb/lottie-react-native.git gh-pages && git checkout -b gh-pages && git add . && git commit -am 'update book' && git push git@github.com:airbnb/lottie-react-native.git gh-pages --force",
+    "docs:publish":
+      "npm run docs:clean && npm run docs:build && cd _book && git init && git commit --allow-empty -m 'update book' && git fetch git@github.com:airbnb/lottie-react-native.git gh-pages && git checkout -b gh-pages && git add . && git commit -am 'update book' && git push git@github.com:airbnb/lottie-react-native.git gh-pages --force",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/airbnb/lottie-react-native.git"
+    "url": "git+https://github.com/react-native-community/lottie-react-native.git"
   },
-  "keywords": [
-    "lottie",
-    "animation",
-    "react",
-    "react-native",
-    "keyframe"
-  ],
-  "author": "Leland Richardson <leland.richardson@airbnb.com>",
+  "keywords": ["lottie", "animation", "react", "react-native", "keyframe"],
+  "author": "Emilio Rodriguez <emiliorodriguez@gmail.com>",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/airbnb/lottie-react-native/issues"
+    "url": "https://github.com/react-native-community/lottie-react-native/issues"
   },
   "homepage": "https://github.com/airbnb/lottie-react-native#readme",
   "peerDependencies": {

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -32,5 +32,5 @@ dependencies {
 
   implementation "com.facebook.react:react-native:+"
   implementation "androidx.appcompat:appcompat:1.0.0"
-  implementation 'com.airbnb.android:lottie:2.5.6'
+  implementation 'com.airbnb.android:lottie:3.0.0'
 }

--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
@@ -162,30 +162,6 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
     getOrCreatePropertyManager(view).setAnimationJson(json);
   }
 
-  /**
-   *
-   * @param view
-   * @param name
-   */
-  @ReactProp(name = "cacheStrategy")
-  public void setCacheStrategy(LottieAnimationView view, String name) {
-    if (name != null) {
-      LottieAnimationView.CacheStrategy strategy = LottieAnimationView.DEFAULT_CACHE_STRATEGY;
-      switch (name) {
-        case "none":
-          strategy = LottieAnimationView.CacheStrategy.None;
-          break;
-        case "weak":
-           strategy = LottieAnimationView.CacheStrategy.Weak;
-           break;
-        case "strong":
-          strategy = LottieAnimationView.CacheStrategy.Strong;
-          break;
-      }
-      getOrCreatePropertyManager(view).setCacheStrategy(strategy);
-    }
-  }
-
   @ReactProp(name = "resizeMode")
   public void setResizeMode(LottieAnimationView view, String resizeMode) {
     ImageView.ScaleType mode = null;
@@ -212,11 +188,6 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
   @ReactProp(name = "loop")
   public void setLoop(LottieAnimationView view, boolean loop) {
     getOrCreatePropertyManager(view).setLoop(loop);
-  }
-
-  @ReactProp(name = "hardwareAccelerationAndroid")
-  public void setHardwareAcceleration(LottieAnimationView view, boolean use) {
-    getOrCreatePropertyManager(view).setUseHardwareAcceleration(use);
   }
 
   @ReactProp(name = "imageAssetsFolder")

--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.java
@@ -33,8 +33,6 @@ public class LottieAnimationViewPropertyManager {
   private boolean animationNameDirty;
 
   private String animationName;
-  private LottieAnimationView.CacheStrategy cacheStrategy;
-  private Boolean useHardwareAcceleration;
   private ImageView.ScaleType scaleType;
   private String imageAssetsFolder;
   private Boolean enableMergePaths;
@@ -52,11 +50,6 @@ public class LottieAnimationViewPropertyManager {
     this.animationJson = json;
   }
 
-  public void setCacheStrategy(LottieAnimationView.CacheStrategy strategy) {
-    this.cacheStrategy = strategy;
-    this.animationNameDirty = true;
-  }
-
   public void setProgress(Float progress) {
     this.progress = progress;
   }
@@ -67,10 +60,6 @@ public class LottieAnimationViewPropertyManager {
 
   public void setLoop(boolean loop) {
     this.loop = loop;
-  }
-
-  public void setUseHardwareAcceleration(boolean useHardwareAcceleration) {
-    this.useHardwareAcceleration = useHardwareAcceleration;
   }
 
   public void setScaleType(ImageView.ScaleType scaleType) {
@@ -101,12 +90,12 @@ public class LottieAnimationViewPropertyManager {
     }
 
     if (animationJson != null) {
-      view.setAnimation(new JsonReader(new StringReader(animationJson)));
+      view.setAnimationFromJson(animationJson, Integer.toString(animationJson.hashCode()));
       animationJson = null;
     }
 
     if (animationNameDirty) {
-      view.setAnimation(animationName, cacheStrategy);
+      view.setAnimation(animationName);
       animationNameDirty = false;
     }
 
@@ -123,11 +112,6 @@ public class LottieAnimationViewPropertyManager {
     if (speed != null) {
       view.setSpeed(speed);
       speed = null;
-    }
-
-    if (useHardwareAcceleration != null) {
-      view.useHardwareAcceleration(useHardwareAcceleration);
-      useHardwareAcceleration = null;
     }
 
     if (scaleType != null) {

--- a/src/js/LottieView.js
+++ b/src/js/LottieView.js
@@ -60,8 +60,6 @@ const propTypes = {
   autoSize: PropTypes.bool,
   enableMergePathsAndroidForKitKatAndAbove: PropTypes.bool,
   source: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
-  hardwareAccelerationAndroid: PropTypes.bool,
-  cacheStrategy: PropTypes.oneOf(['none', 'weak', 'strong']),
   onAnimationFinish: PropTypes.func,
 };
 


### PR DESCRIPTION
# Summary

This PR adds support for Lottie Android 3.0.0

## Test Plan

Apps using `lottie-react-native` should still work on android.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅    |

## Checklist

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
