### PR TITLE
Fix loading assets from app bundle on iOS

### DIFF
--- a/src/ios/LottieReactNative/ContainerView.swift
+++ b/src/ios/LottieReactNative/ContainerView.swift
@@ -50,7 +50,13 @@ class ContainerView: RCTView {
     }
     
     @objc func setSourceName(_ newSourceName: String) {
+        if (newSourceName == sourceName) {
+          return
+        }
         sourceName = newSourceName
+
+        let starAnimationView = AnimationView(name: sourceName)
+        replaceAnimationView(next: starAnimationView)
     }
     
     @objc func setResizeMode(_ resizeMode: String) {


### PR DESCRIPTION
# Summary

The method for loading named assets on iOS wasn't actually doing anything. I added a simple implementation using AnimatedView(name:) which does exactly what we want and also takes care of caching the loaded animation.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

None

### What are the steps to reproduce (after prerequisites)?

- Add an animation json to your xcode project
- Add a lottie view like: `<LottieView source="nameOfAnimationWithNoExtension" />

## Compatibility

N/A

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
