### PR TITLE
Remove unused deprecated `publishNonDefault` Gradle option

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -10,7 +10,6 @@ apply from: 'gradle-maven-push.gradle'
 android {
   compileSdkVersion safeExtGet('compileSdkVersion', 28)
   buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
-  publishNonDefault true
 
   defaultConfig {
     minSdkVersion safeExtGet('minSdkVersion', 16)


### PR DESCRIPTION
This config line is not used and results in a warning when building:

```
> Configure project :lottie-react-native
publishNonDefault is deprecated and has no effect anymore. All variants are now published.
```

Fixes #534 

