### PR TITLE
Support passing extensionless file names on Android

### DIFF
--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
@@ -154,6 +154,14 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
 
   @ReactProp(name = "sourceName")
   public void setSourceName(LottieAnimationView view, String name) {
+    // To match the behaviour on iOS we expect the source name to be
+    // extensionless. This means "myAnimation" corresponds to a file
+    // named `myAnimation.json` in `main/assets`. To maintain backwards
+    // compatibility we only add the .json extension if no extension is
+    // passed.
+    if (!name.contains(".")) {
+      name = name + ".json";
+    }
     getOrCreatePropertyManager(view).setAnimationName(name);
   }
 


### PR DESCRIPTION
# Summary

To match the behaviour on iOS this adds a .json extension when not specified. This allow writing the same JS code for iOS and Android when using assets by name.

## Test Plan

Tested that passing an asset by name without an extension will work on both iOS and Android.

```js
// This will find a file named `my_animation.json` in `main/assets` on Android and
// `my_animation.json` added to the xcode project on iOS.
<LottieView source="my_animation" />
```

## Compatibility

N/A

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
