### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,17 +58,17 @@ project(':lottie-react-native').projectDir = new File(rootProject.projectDir, '.
 
 ## Installing (React Native == 0.59.x)
 
-Install `lottie-react-native` (latest) and `lottie-ios` (3.0.3):
+Install `lottie-react-native` (3.0.2) and `lottie-ios` (3.0.3):
 
 ```
-yarn add lottie-react-native
+yarn add lottie-react-native@3.0.2
 yarn add lottie-ios@3.0.3
 ```
 
 or
 
 ```
-npm i --save lottie-react-native
+npm i --save lottie-react-native@3.0.2
 npm i --save lottie-ios@3.0.3
 ```
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary


The react-native 0.59.X version doesn't support androidX library, so the last available version of lottie-react-native support only the androidX project.
To solve this problem I changed, on README 0.59.X section and replace `(latest)` with the last version available without androidX support (3.0.2).

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
