### PR TITLE
Fix android crash when .play() startFrame > endFrame

### DIFF
--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
@@ -113,7 +113,12 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
             int startFrame = args.getInt(0);
             int endFrame = args.getInt(1);
             if (startFrame != -1 && endFrame != -1) {
-              view.setMinAndMaxFrame(args.getInt(0), args.getInt(1));
+               if(startFrame > endFrame){
+                view.setMinAndMaxFrame(endFrame, startFrame );
+                view.reverseAnimationSpeed();
+              } else{
+                view.setMinAndMaxFrame(startFrame, endFrame);
+              }
             }
             if (ViewCompat.isAttachedToWindow(view)) {
               view.setProgress(0f);


### PR DESCRIPTION
Trying to fix #522 

I'm new to this. My changes to the java classes have no effect when i run it locally with expo. I tried to build with gradle but still no effect. I read the contributing guidelines but was no wiser.

Any help would be appreciated. 