### PR TITLE
Make ContainerView class public

### DIFF
--- a/src/ios/LottieReactNative/ContainerView.swift
+++ b/src/ios/LottieReactNative/ContainerView.swift
@@ -4,7 +4,7 @@ import React
 
 import Lottie
 
-class ContainerView: RCTView {
+public class ContainerView: RCTView {
     private var speed: CGFloat = 0.0
     private var progress: CGFloat = 0.0
     private var loop: LottieLoopMode = .playOnce
@@ -12,7 +12,7 @@ class ContainerView: RCTView {
     private var resizeMode: String = ""
     private var sourceName: String = ""
     @objc var onAnimationFinish: RCTBubblingEventBlock?
-    var animationView: AnimationView?
+    public var animationView: AnimationView?
 
     @objc func setSpeed(_ newSpeed: CGFloat) {
         speed = newSpeed
@@ -23,7 +23,7 @@ class ContainerView: RCTView {
         animationView?.currentProgress = progress
     }
     
-    override func reactSetFrame(_ frame: CGRect) {
+    override public func reactSetFrame(_ frame: CGRect) {
         super.reactSetFrame(frame)
         animationView?.reactSetFrame(frame)
     }


### PR DESCRIPTION
Hi! Thanks for cool wrapper

# Summary
We save Lottie animations as video in our project and we need `ContainerView` and `ContainerView.animationView` property to be public for our iOS-native export process

## Details
- We send `findNodeHandle(lottieRef)` to native code and check it's class (we use it as `ContainerView` later)
- We set `AnimationView.currentProgress` property deep inside Swift code
- We call `AnimationView.start()`, `AnimationView.stop()` a lot
- We get animation meta from `AnimationView.animation`

## Checklist
- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
