### PR TITLE
Fix animation stops when ui block or scroll (iOS)

### DIFF
--- a/src/ios/LottieReactNative/ContainerView.swift
+++ b/src/ios/LottieReactNative/ContainerView.swift
@@ -73,10 +73,12 @@ class ContainerView: RCTView {
     
     
     func play(fromFrame: AnimationFrameTime? = nil, toFrame: AnimationFrameTime, completion: LottieCompletionBlock? = nil) {
+        animationView?.backgroundBehavior = .pauseAndRestore
         animationView?.play(fromFrame: fromFrame, toFrame: toFrame, loopMode: self.loop, completion: completion);
     }
     
     func play(completion: LottieCompletionBlock? = nil) {
+        animationView?.backgroundBehavior = .pauseAndRestore
         animationView?.play(completion: completion)
     }
     


### PR DESCRIPTION
Fix AnimationUIblock on scroll or when mounting and unmounting components in ios


# Summary

* What issues does the pull request solve? #412 #560 #530 #496 
* How did you implement the solution?   
`animationView?.backgroundBehavior = .pauseAndRestore` when animation plays inside `ContainerView.swift` file!

## Test Plan

Change tabs and scroll like and it should work like as charm!

### What's required for testing (prerequisites)?
Scroll lottie inside scrollview or navigate between screens and tabs!


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |


## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
