### PR TITLE
Add support for color filters by layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unrealeased
+- Added `colorFilters` prop for setting individually layers color
+
 ## 3.2.1 (Sep 30, 2019)
 
 - Fix for strange characters in some Java files

--- a/README.md
+++ b/README.md
@@ -200,6 +200,32 @@ export default class BasicExample extends React.Component {
 }
 ```
 
+Changing color of layers:
+
+```jsx
+import React from 'react';
+import LottieView from 'lottie-react-native';
+
+export default class BasicExample extends React.Component {
+  render() {
+    return (
+      <LottieView
+        source={require('../path/to/animation.json')}
+        colorFilters={[{
+          keypath: "button",
+          color: "#F00000"
+        },{
+          keypath: "Sending Loader",
+          color: "#F00000"
+        }]}
+        autoPlay
+        loop
+      />
+    );
+  }
+}
+```
+
 ## API
 
 You can find the full list of props and methods available in our [API document](https://github.com/airbnb/lottie-react-native/blob/master/docs/api.md). These are the most common ones:
@@ -210,6 +236,7 @@ You can find the full list of props and methods available in our [API document](
 | **`style`**    | Style attributes for the view, as expected in a standard [`View`](https://facebook.github.io/react-native/docs/layout-props.html).                                                                                                                                              | The `aspectRatio` exported by Bodymovin will be set. Also the `width` if you haven't provided a `width` or `height` |
 | **`loop`**     | A boolean flag indicating whether or not the animation should loop.                                                                                                                                                                                                             | `true`                                                                                                              |
 | **`autoPlay`** | A boolean flag indicating whether or not the animation should start automatically when mounted. This only affects the imperative API.                                                                                                                                           | `false`                                                                                                             |
+| **`colorFilters`** | An Array of layers you want to change the color filter.                                                                                                                                           | `[]`                                                                                                             |
 
 [More...](https://github.com/airbnb/lottie-react-native/blob/master/docs/api.md)
 

--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
@@ -213,6 +213,11 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
     getOrCreatePropertyManager(view).setEnableMergePaths(enableMergePaths);
   }
 
+  @ReactProp(name = "colorFilters")
+  public void setColorFilters(LottieAnimationView view, ReadableArray colorFilters) {
+    getOrCreatePropertyManager(view).setColorFilters(colorFilters);
+  }
+
   @Override
   protected void onAfterUpdateTransaction(LottieAnimationView view) {
     super.onAfterUpdateTransaction(view);

--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.java
@@ -1,12 +1,17 @@
 package com.airbnb.android.react.lottie;
 
-import android.util.JsonReader;
+import android.graphics.Color;
+import android.graphics.ColorFilter;
 import android.widget.ImageView;
 
 import com.airbnb.lottie.LottieAnimationView;
 import com.airbnb.lottie.LottieDrawable;
-
-import java.io.StringReader;
+import com.airbnb.lottie.LottieProperty;
+import com.airbnb.lottie.SimpleColorFilter;
+import com.airbnb.lottie.model.KeyPath;
+import com.airbnb.lottie.value.LottieValueCallback;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
 import java.lang.ref.WeakReference;
 
 /**
@@ -36,6 +41,7 @@ public class LottieAnimationViewPropertyManager {
   private ImageView.ScaleType scaleType;
   private String imageAssetsFolder;
   private Boolean enableMergePaths;
+  private ReadableArray colorFilters;
 
   public LottieAnimationViewPropertyManager(LottieAnimationView view) {
     this.viewWeakReference = new WeakReference<>(view);
@@ -72,6 +78,10 @@ public class LottieAnimationViewPropertyManager {
 
   public void setEnableMergePaths(boolean enableMergePaths) {
     this.enableMergePaths = enableMergePaths;
+  }
+
+  public void setColorFilters(ReadableArray colorFilters) {
+    this.colorFilters = colorFilters;
   }
 
   /**
@@ -125,8 +135,20 @@ public class LottieAnimationViewPropertyManager {
     }
 
     if (enableMergePaths != null) {
-        view.enableMergePathsForKitKatAndAbove(enableMergePaths);
-        enableMergePaths = null;
+      view.enableMergePathsForKitKatAndAbove(enableMergePaths);
+      enableMergePaths = null;
+    }
+
+    if (colorFilters != null && colorFilters.size() > 0) {
+      for (int i = 0 ; i < colorFilters.size() ; i++) {
+        ReadableMap current = colorFilters.getMap(i);
+        String color = current.getString("color");
+        String path = current.getString("keypath");
+        SimpleColorFilter colorFilter = new SimpleColorFilter(Color.parseColor(color));
+        KeyPath keyPath = new KeyPath(path);
+        LottieValueCallback<ColorFilter> callback = new LottieValueCallback<>(colorFilter);
+        view.addValueCallback(keyPath, LottieProperty.COLOR_FILTER, callback);
+      }
     }
   }
 }

--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.java
@@ -145,7 +145,7 @@ public class LottieAnimationViewPropertyManager {
         String color = current.getString("color");
         String path = current.getString("keypath");
         SimpleColorFilter colorFilter = new SimpleColorFilter(Color.parseColor(color));
-        KeyPath keyPath = new KeyPath(path);
+        KeyPath keyPath = new KeyPath(path, "**");
         LottieValueCallback<ColorFilter> callback = new LottieValueCallback<>(colorFilter);
         view.addValueCallback(keyPath, LottieProperty.COLOR_FILTER, callback);
       }

--- a/src/ios/LottieReactNative/ContainerView.swift
+++ b/src/ios/LottieReactNative/ContainerView.swift
@@ -11,28 +11,29 @@ class ContainerView: RCTView {
     private var sourceJson: String = ""
     private var resizeMode: String = ""
     private var sourceName: String = ""
+    private var colorFilters: [NSDictionary] = []
     @objc var onAnimationFinish: RCTBubblingEventBlock?
     var animationView: AnimationView?
 
     @objc func setSpeed(_ newSpeed: CGFloat) {
         speed = newSpeed
     }
-    
+
     @objc func setProgress(_ newProgress: CGFloat) {
         progress = newProgress
         animationView?.currentProgress = progress
     }
-    
+
     override func reactSetFrame(_ frame: CGRect) {
         super.reactSetFrame(frame)
         animationView?.reactSetFrame(frame)
     }
-    
+
     @objc func setLoop(_ isLooping: Bool) {
         loop = isLooping ? .loop : .playOnce
         animationView?.loopMode = loop
     }
-    
+
     @objc func setSourceJson(_ newSourceJson: String) {
         sourceJson = newSourceJson
 
@@ -48,7 +49,7 @@ class ContainerView: RCTView {
         starAnimationView.animation = animation
         replaceAnimationView(next: starAnimationView)
     }
-    
+
     @objc func setSourceName(_ newSourceName: String) {
         if (newSourceName == sourceName) {
           return
@@ -58,7 +59,7 @@ class ContainerView: RCTView {
         let starAnimationView = AnimationView(name: sourceName)
         replaceAnimationView(next: starAnimationView)
     }
-    
+
     @objc func setResizeMode(_ resizeMode: String) {
         switch (resizeMode) {
         case "cover":
@@ -70,25 +71,55 @@ class ContainerView: RCTView {
         default: break
         }
     }
-    
-    
+
+    @objc func setColorFilters(_ newColorFilters: [NSDictionary]) {
+        colorFilters = newColorFilters
+        applyProperties()
+    }
+
+    func hexStringToUIColor(hex: String) -> UIColor {
+        var cString:String = hex.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+
+        if (cString.hasPrefix("#")) {
+            cString.remove(at: cString.startIndex)
+        }
+
+        if ((cString.count) == 0) {
+            return UIColor.red
+        }
+
+        if ((cString.count) != 6) {
+            return UIColor.green
+        }
+
+        var rgbValue:UInt32 = 0
+        Scanner(string: cString).scanHexInt32(&rgbValue)
+
+        return UIColor(
+            red: CGFloat((rgbValue & 0xFF0000) >> 16) / 255.0,
+            green: CGFloat((rgbValue & 0x00FF00) >> 8) / 255.0,
+            blue: CGFloat(rgbValue & 0x0000FF) / 255.0,
+            alpha: CGFloat(1.0)
+        )
+    }
+
     func play(fromFrame: AnimationFrameTime? = nil, toFrame: AnimationFrameTime, completion: LottieCompletionBlock? = nil) {
         animationView?.backgroundBehavior = .pauseAndRestore
         animationView?.play(fromFrame: fromFrame, toFrame: toFrame, loopMode: self.loop, completion: completion);
     }
-    
+
     func play(completion: LottieCompletionBlock? = nil) {
         animationView?.backgroundBehavior = .pauseAndRestore
         animationView?.play(completion: completion)
     }
-    
+
     func reset() {
         animationView?.currentProgress = 0;
         animationView?.pause()
     }
-    
+
     // MARK: Private
-    
+
     func replaceAnimationView(next: AnimationView) {
         animationView?.removeFromSuperview()
 
@@ -99,10 +130,18 @@ class ContainerView: RCTView {
         animationView?.reactSetFrame(frame)
         applyProperties()
     }
-    
+
     func applyProperties() {
         animationView?.currentProgress = progress
         animationView?.animationSpeed = speed
         animationView?.loopMode = loop
+        if (colorFilters.count > 0) {
+            for filter in colorFilters {
+                let keypath: String = "\(filter.value(forKey: "keypath") as! String).**.Color"
+                let fillKeypath = AnimationKeypath(keypath: keypath)
+                let colorFilterValueProvider = ColorValueProvider(hexStringToUIColor(hex: filter.value(forKey: "color") as! String).lottieColorValue)
+                animationView?.setValueProvider(colorFilterValueProvider, keypath: fillKeypath)
+            }
+        }
     }
 }

--- a/src/ios/LottieReactNative/LRNAnimationViewManagerObjC.m
+++ b/src/ios/LottieReactNative/LRNAnimationViewManagerObjC.m
@@ -9,6 +9,7 @@ RCT_EXPORT_VIEW_PROPERTY(progress, CGFloat);
 RCT_EXPORT_VIEW_PROPERTY(loop, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(speed, CGFloat);
 RCT_EXPORT_VIEW_PROPERTY(onAnimationFinish, RCTBubblingEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(colorFilters, NSArray);
 
 RCT_EXTERN_METHOD(play:(nonnull NSNumber *)reactTag fromFrame:(nonnull NSNumber *) startFrame toFrame:(nonnull NSNumber *) endFrame);
 

--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -16,6 +16,11 @@ declare module "lottie-react-native" {
     layers: any[];
   }
 
+  type ColorFilter = {
+    keypath: string;
+    color: string;
+  }
+
   /**
    * Properties of the AnimatedLottieView component
    */
@@ -41,7 +46,7 @@ declare module "lottie-react-native" {
      * default value is 1.
      */
     speed?: number;
-    
+
     /**
      * The duration of the animation in ms. Takes precedence over speed when set.
      * This only works when source is an actual JS object of an animation.
@@ -77,7 +82,7 @@ declare module "lottie-react-native" {
     hardwareAccelerationAndroid?: boolean;
 
     /**
-     * Determines how to resize the animated view when the frame doesn't match the raw image 
+     * Determines how to resize the animated view when the frame doesn't match the raw image
      * dimensions.
      * Refer to https://facebook.github.io/react-native/docs/image.html#resizemode
      */
@@ -99,13 +104,13 @@ declare module "lottie-react-native" {
 
     /**
      * A boolean flag indicating whether or not the animation should size itself automatically
-     * according to the width in the animation's JSON. This only works when source is an actual 
+     * according to the width in the animation's JSON. This only works when source is an actual
      * JS object of an animation.
      */
     autoSize?: boolean;
 
     /**
-     * A boolean flag to enable merge patching in android.  
+     * A boolean flag to enable merge patching in android.
      */
     enableMergePathsAndroidForKitKatAndAbove?: boolean;
 
@@ -114,14 +119,19 @@ declare module "lottie-react-native" {
      * callback will be called only when `loop` is set to false.
      */
     onAnimationFinish ?: (isCancelled: boolean) => void;
+
+    /**
+     * An array of layers you want to override its color filter.
+     */
+    colorFilters ?: Array<ColorFilter>;
   }
 
   /**
    * View hosting the lottie animation. In order to successfully import this definition in
    * your typescript file, you need to import the view as:
-   * 
+   *
    * `import LottieView = require("lottie-react-native");`
-   * 
+   *
    * Otherwise the compiler will give you issues and won't work.
    */
   class AnimatedLottieView extends React.Component<AnimatedLottieViewProps, {}> {


### PR DESCRIPTION
# Summary

Added support to override color of a layer (solves #180) following [android](http://airbnb.io/lottie/#/android?id=looping) and [ios](http://airbnb.io/lottie/#/ios) documentations.

```javascript
colorFilters={[{
              keypath: layer,
              color: colorHex
            }]}
```
### What's required for testing (prerequisites)?
Just install the package and try to override one layer color.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
