### PR TITLE
fix: Fixed ios isCancelled in onAnimationFinish getting the wrong value

### DIFF
--- a/src/ios/LottieReactNative/AnimationViewManagerModule.swift
+++ b/src/ios/LottieReactNative/AnimationViewManagerModule.swift
@@ -28,7 +28,7 @@ class AnimationViewManagerModule: RCTViewManager {
 
             let callback: LottieCompletionBlock = { animationFinished in
                 if let onFinish = view.onAnimationFinish {
-                    onFinish(["isCancelled": animationFinished])
+                    onFinish(["isCancelled": !animationFinished])
                 }
             }
 


### PR DESCRIPTION
# Summary
Fixing an issue that in newer version of lottie-react-native isCanceled having wrong value and a different value than the android

* What areas of the library does it impact?
the ios version of the library
-->

### What are the steps to reproduce (after prerequisites)?

- run any lottie animation using the library and add onAnimationFinish callback and log the isCancelled parameter

- interrupt that animation 

- Android: isCancelled is true while on ios: isCancelled is false

- After change both android and ios will have isCancelled true


## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
