### PR TITLE
Update api.md

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -4,7 +4,7 @@
 |---|---|---|
 |**`source`**| **Mandatory** - The source of animation. Can be referenced as a local asset by a string, or remotely with an object with a `uri` property, or it can be an actual JS object of an animation, obtained (for example) with something like `require('../path/to/animation.json')` |*None*|
 |**`progress`**| A number between 0 and 1, or an `Animated` number between 0 and 1. This number represents the normalized progress of the animation. If you update this prop, the animation will correspondingly update to the frame at that progress value. This prop is not required if you are using the imperative API. |`0`|
-|**`speed`**| The speed the animation will progress. This only affects the imperative API. Sending a negative value will reverse the animation |`1`|
+|**`speed`**| The speed the animation will progress. Sending a negative value will reverse the animation |`1`|
 |**`duration`**| The duration of the animation in ms. Takes precedence over `speed` when set. This only works when `source` is an actual JS object of an animation. |`undefined`|
 |**`loop`**|A boolean flag indicating whether or not the animation should loop. |`true`|
 |**`autoPlay`**|A boolean flag indicating whether or not the animation should start automatically when mounted. This only affects the imperative API.  |`false`|


### PR DESCRIPTION
The sentence about using the imperative API seems obsolete. I have tried on both iOS and Android using the `speed` props with the declarative API and it was working perfectly well.

# Summary

Documentation PR

## Test Plan

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

## Checklist
