### PR TITLE
Remove references to colorFilters prop from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,31 +202,6 @@ export default class BasicExample extends React.Component {
 }
 ```
 
-Changing color of layers:
-
-```jsx
-import React from 'react';
-import LottieView from 'lottie-react-native';
-
-export default class BasicExample extends React.Component {
-  render() {
-    return (
-      <LottieView
-        source={require('../path/to/animation.json')}
-        colorFilters={[{
-          keypath: "button",
-          color: "#F00000"
-        },{
-          keypath: "Sending Loader",
-          color: "#F00000"
-        }]}
-        autoPlay
-        loop
-      />
-    );
-  }
-}
-```
 
 ## API
 
@@ -238,7 +213,6 @@ You can find the full list of props and methods available in our [API document](
 | **`style`**    | Style attributes for the view, as expected in a standard [`View`](https://facebook.github.io/react-native/docs/layout-props.html).                                                                                                                                              | The `aspectRatio` exported by Bodymovin will be set. Also the `width` if you haven't provided a `width` or `height` |
 | **`loop`**     | A boolean flag indicating whether or not the animation should loop.                                                                                                                                                                                                             | `true`                                                                                                              |
 | **`autoPlay`** | A boolean flag indicating whether or not the animation should start automatically when mounted. This only affects the imperative API.                                                                                                                                           | `false`                                                                                                             |
-| **`colorFilters`** | An Array of layers you want to change the color filter.                                                                                                                                           | `[]`                                                                                                             |
 
 [More...](https://github.com/airbnb/lottie-react-native/blob/master/docs/api.md)
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Docs are pointing to the existence of `colorFilters` prop on LottieView, but it doesn't seem like it is really supported. Source code doesn't mention it, and it doesn't work.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
