### PR TITLE
Fix #598. Add new logic to setSpeed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.3
+- Fix iOS speed not changing dynamically
+
 ## 3.3.2 (Nov 15, 2019)
 
 - Removed support for `Reanimated`

--- a/src/ios/LottieReactNative/ContainerView.swift
+++ b/src/ios/LottieReactNative/ContainerView.swift
@@ -17,6 +17,15 @@ class ContainerView: RCTView {
 
     @objc func setSpeed(_ newSpeed: CGFloat) {
         speed = newSpeed
+        
+        if (newSpeed != 0.0) {
+            animationView?.animationSpeed = newSpeed
+            if (!(animationView?.isAnimationPlaying ?? true)) {
+                animationView?.play()
+            }
+        } else if (animationView?.isAnimationPlaying ?? false) {
+            animationView?.pause()
+        }
     }
 
     @objc func setProgress(_ newProgress: CGFloat) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
It will fix #598 by changing the animation speed on setSpeed method on native code. 
It will also play or pause the animation according to the speed.
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What are the steps to reproduce (after prerequisites)?

- Start with an animation speed of 0
- Change it to 1 after a few seconds. The animation should play
- Change it back to 0. The animation should pause

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device
- [ ] I have tested this on a simulator
- [ ] I added the documentation in `README.md`
- [x] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
