### PR TITLE
use Swift 5.0

### DIFF
--- a/lottie-react-native.podspec
+++ b/lottie-react-native.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/react-community/lottie-react-native.git", :tag => "v#{s.version}" }
   s.source_files  = "src/ios/**/*.{h,m,swift}"
-  s.swift_version = "4.2"
+  s.swift_version = "5.0"
   s.dependency 'React'
   s.dependency 'lottie-ios', '~> 3.1.3'
 end


### PR DESCRIPTION
# Summary

Swift 5.0 is commonly used because of ABI stability, and Xcode is asking the project to be migrated to 5.0. Swift 4.2 code require no change, thus compatible with 5.0.

## Test Plan

Compiles and works as expected.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
