### PR TITLE
Use react-native-reanimated if present

### DIFF
--- a/src/js/LottieView.js
+++ b/src/js/LottieView.js
@@ -8,6 +8,12 @@ import {
   StyleSheet,
   ViewPropTypes,
 } from 'react-native';
+let Reanimated;
+try {
+  Reanimated = require('react-native-reanimated').default;
+} catch (e) {
+  // react-native-reanimated isn't installed, we'll fallback on React.Animated
+}
 import SafeModule from 'react-native-safe-modules';
 import PropTypes from 'prop-types';
 
@@ -16,6 +22,9 @@ const NativeLottieView = SafeModule.component({
   mockComponent: View,
 });
 const AnimatedNativeLottieView = Animated.createAnimatedComponent(NativeLottieView);
+const ReanimatedNativeLottieView = Reanimated
+  ? Reanimated.createAnimatedComponent(NativeLottieView)
+  : undefined;
 
 const LottieViewManager = SafeModule.module({
   moduleName: 'LottieAnimationView',
@@ -167,20 +176,32 @@ class LottieView extends React.Component {
 
     const speed =
       this.props.duration && sourceJson && this.props.source.fr
-        ? Math.round(this.props.source.op / this.props.source.fr * 1000 / this.props.duration)
+        ? Math.round(((this.props.source.op / this.props.source.fr) * 1000) / this.props.duration)
         : this.props.speed;
 
     return (
       <View style={[aspectRatioStyle, sizeStyle, style]}>
-        <AnimatedNativeLottieView
-          ref={this.refRoot}
-          {...rest}
-          speed={speed}
-          style={[aspectRatioStyle, sizeStyle || { width: '100%', height: '100%' }, style]}
-          sourceName={sourceName}
-          sourceJson={sourceJson}
-          onAnimationFinish={this.onAnimationFinish}
-        />
+        {Reanimated && this.props.progress instanceof Reanimated.Node ? (
+          <ReanimatedNativeLottieView
+            ref={this.refRoot}
+            {...rest}
+            speed={speed}
+            style={[aspectRatioStyle, sizeStyle || { width: '100%', height: '100%' }, style]}
+            sourceName={sourceName}
+            sourceJson={sourceJson}
+            onAnimationFinish={this.onAnimationFinish}
+          />
+        ) : (
+          <AnimatedNativeLottieView
+            ref={this.refRoot}
+            {...rest}
+            speed={speed}
+            style={[aspectRatioStyle, sizeStyle || { width: '100%', height: '100%' }, style]}
+            sourceName={sourceName}
+            sourceJson={sourceJson}
+            onAnimationFinish={this.onAnimationFinish}
+          />
+        )}
       </View>
     );
   }

--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -39,7 +39,7 @@ declare module "lottie-react-native" {
      * animation will correspondingly update to the frame at that progress value. This
      * prop is not required if you are using the imperative API.
      */
-    progress?: number | Animated.Value;
+    progress?: number | Animated.Value | any;
 
     /**
      * The speed the animation will progress. This only affects the imperative API. The


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Add support for react-native-reanimated. Contrary to https://github.com/react-native-community/lottie-react-native/pull/585 it's not necessary to have react-native-reanimated installed (it's not added as a peer dependency). We try to import it, and if it succeed, then we test if `progress` is a reanimated node, and if that's the case we create a reanimated component (most of the code comes from @JoaoLSS in the related MR).

## Test Plan

It should work as previously in applications without react-native-reanimated.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
