### PR TITLE
fix(colorfilter): colorfilter path issue has been fixed for android

### DIFF
--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.java
@@ -13,7 +13,7 @@ import com.airbnb.lottie.value.LottieValueCallback;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import java.lang.ref.WeakReference;
-
+import java.util.regex.Pattern;
 /**
  * Class responsible for applying the properties to the LottieView.
  * The way react-native works makes it impossible to predict in which order properties will be set,
@@ -145,7 +145,9 @@ public class LottieAnimationViewPropertyManager {
         String color = current.getString("color");
         String path = current.getString("keypath");
         SimpleColorFilter colorFilter = new SimpleColorFilter(Color.parseColor(color));
-        KeyPath keyPath = new KeyPath(path, "**");
+        String pathWithGlobstar = path +".**";
+        String[] keys = pathWithGlobstar.split(Pattern.quote("."));
+        KeyPath keyPath = new  KeyPath(keys);
         LottieValueCallback<ColorFilter> callback = new LottieValueCallback<>(colorFilter);
         view.addValueCallback(keyPath, LottieProperty.COLOR_FILTER, callback);
       }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR solves, changing color issue  for child elements in Android 

Normally we can change child elements colors with passing a dot in the keypath in IOS

`
    {
      keypath: 'Flyer.#Primary Front Arm',
      color: '#FFFF00',
    }
`

But it is not working for Android because the constructor of KeyPath class needs a java varargs types and in the code, we are directly passing path as a string to KeyPath constructor

In this PR I have split the path variable with the dot and called KeyPath constructor with a string array


`
  public KeyPath(String... keys) {
    this.keys = Arrays.asList(keys);
  }
`



## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

Try to change a child element color with colorFilters in Android
 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
