### PR TITLE
Recommend pod-install for setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,11 @@ Use `react-native link` to add the library to your project:
 react-native link lottie-ios
 react-native link lottie-react-native
 ```
-Note: 
 
-Go to your ios folder and run:
+Link the native iOS code by running:
 
 ```
-pod install
+npx pod-install
 ```
 
 **_ IMPORTANT _**


### PR DESCRIPTION
# Summary

We've been recommending devs use `npx pod-install` since it will attempt to install CocoaPods CLI if it's not available on the computer (cite [React Navigation setup guide](https://reactnavigation.org/docs/getting-started/#installing-dependencies-into-a-bare-react-native-project)). This has proved very useful for Expo users who are now migrating to the bare workflow and want to use community packages in their projects.

## Checklist

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`