### PR TITLE
Add renderMode property for Android

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -12,6 +12,7 @@
 |**`style`**|Style attributes for the view, as expected in a standard [`View`](http://facebook.github.io/react-native/releases/0.46/docs/layout-props.html), aside from border styling |*None*|
 |**`imageAssetsFolder`**| Needed for **Android** to work properly with assets, iOS will ignore it. |*None*|
 |**`onAnimationFinish`**| A callback function which will be called when animation is finished. Note that this callback will be called only when `loop` is set to false. |*None*|
+|**`renderMode`**| **Only Android**, a String flag to set whether or not to render with `HARDWARE` or `SOFTWARE` acceleration |`AUTOMATIC`|
 
 ## Methods (Imperative API):
 

--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
@@ -11,6 +11,7 @@ import android.view.View.OnAttachStateChangeListener;
 import android.view.View;
 
 import com.airbnb.lottie.LottieAnimationView;
+import com.airbnb.lottie.RenderMode;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
@@ -212,6 +213,19 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
       mode = ImageView.ScaleType.CENTER;
     }
     getOrCreatePropertyManager(view).setScaleType(mode);
+  }
+
+  @ReactProp(name = "renderMode")
+  public void setRenderMode(LottieAnimationView view, String renderMode) {
+    RenderMode mode = null;
+    if ("AUTOMATIC".equals(renderMode) ){
+      mode = RenderMode.AUTOMATIC;
+    }else if ("HARDWARE".equals(renderMode)){
+      mode = RenderMode.HARDWARE;
+    }else if ("SOFTWARE".equals(renderMode)){
+      mode = RenderMode.SOFTWARE;
+    }
+    getOrCreatePropertyManager(view).setRenderMode(mode);
   }
 
   @ReactProp(name = "progress")

--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.java
@@ -7,6 +7,7 @@ import android.widget.ImageView;
 import com.airbnb.lottie.LottieAnimationView;
 import com.airbnb.lottie.LottieDrawable;
 import com.airbnb.lottie.LottieProperty;
+import com.airbnb.lottie.RenderMode;
 import com.airbnb.lottie.SimpleColorFilter;
 import com.airbnb.lottie.model.KeyPath;
 import com.airbnb.lottie.value.LottieValueCallback;
@@ -42,6 +43,7 @@ public class LottieAnimationViewPropertyManager {
   private String imageAssetsFolder;
   private Boolean enableMergePaths;
   private ReadableArray colorFilters;
+  private RenderMode renderMode;
 
   public LottieAnimationViewPropertyManager(LottieAnimationView view) {
     this.viewWeakReference = new WeakReference<>(view);
@@ -70,6 +72,10 @@ public class LottieAnimationViewPropertyManager {
 
   public void setScaleType(ImageView.ScaleType scaleType) {
     this.scaleType = scaleType;
+  }
+
+  public void setRenderMode(RenderMode renderMode) {
+    this.renderMode = renderMode;
   }
 
   public void setImageAssetsFolder(String imageAssetsFolder) {
@@ -127,6 +133,11 @@ public class LottieAnimationViewPropertyManager {
     if (scaleType != null) {
       view.setScaleType(scaleType);
       scaleType = null;
+    }
+
+    if (renderMode != null) {
+      view.setRenderMode(renderMode);
+      renderMode = null;
     }
 
     if (imageAssetsFolder != null) {

--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -89,6 +89,12 @@ declare module "lottie-react-native" {
     resizeMode?: "cover" | "contain" | "center";
 
     /**
+     * Determines how Lottie should render
+     * Refer to LottieAnimationView#setRenderMode(RenderMode) for more information.
+     */
+    renderMode?: "AUTOMATIC" | "HARDWARE" | "SOFTWARE";
+
+    /**
      * [Android]. Allows to specify kind of cache used for animation. Default value weak.
      * strong - cached forever
      * weak   - cached as long it is in active use
@@ -119,7 +125,7 @@ declare module "lottie-react-native" {
      * callback will be called only when `loop` is set to false.
      */
     onAnimationFinish ?: (isCancelled: boolean) => void;
-    
+
     /**
      * A callback function which will be called when the view has been laid out.
      */
@@ -129,7 +135,7 @@ declare module "lottie-react-native" {
      * An array of layers you want to override its color filter.
      */
     colorFilters ?: Array<ColorFilter>;
-    
+
     /**
      * A string to identify the component during testing
      */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
We currently use `lottie-react-native` , recently we received the report of an error that is occurring with some Lottie's with Android 7 and it is related to Hardware acceleration in Android.

Following this issue in this thread
https://github.com/airbnb/lottie-android/issues/1453

We found that it can be solved with a `renderMode` property that is out of the box inside the `lottie-android` library, but this property is not exposed in React Native, so this PR expose it to be used from React Native

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

We already tested this and it's works! 🎉 

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
