### PR TITLE
Fix warnings about pause/resume

### DIFF
--- a/src/js/LottieView.js
+++ b/src/js/LottieView.js
@@ -22,6 +22,8 @@ const LottieViewManager = SafeModule.module({
   mock: {
     play: () => {},
     reset: () => {},
+    pause: () => {},
+    resume: () => {},
     getConstants: () => {},
   },
 });


### PR DESCRIPTION
# Summary
After upgrading to lottie-react-native 3.4.0, the following warnings occur.

```
ReactNative.NativeModules.LottieAnimationView.pause did not have a corresponding prop defined in the mock provided to SafeModule.
ReactNative.NativeModules.LottieAnimationView.resume did not have a corresponding prop defined in the mock provided to SafeModule.
```

This fix is intended to eliminate warnings.

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
