### PR TITLE
Add missing type from reac-native package

### DIFF
--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -1,5 +1,5 @@
 declare module "lottie-react-native" {
-  import { Animated, StyleProp, ViewStyle } from "react-native";
+  import { Animated, StyleProp, ViewStyle, LayoutChangeEvent } from "react-native";
   /**
    * Serialized animation as generated from After Effects
    */


### PR DESCRIPTION
# Summary

When using typescript `typecheck` code validation, typescript is pointing it out that the `LayoutChangeEvent` is missing from the react-native imports in the [`index.d.ts`](https://github.com/react-native-community/lottie-react-native/blob/4f4ff693658cc5def04440732a2e1ab9e3e0491c/src/js/index.d.ts) type definition file.

### What are the steps to reproduce (after prerequisites)?

When running: `tsc --noEmit -p .` from the project folder where typescript is set and `lottie-react-native` is installed and being used, the following error occurs:

- node_modules/lottie-react-native/src/js/index.d.ts(126,24): error TS2304: Cannot find name 'LayoutChangeEvent'

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I updated the typed files (TS and Flow)
